### PR TITLE
JAVASERVERFACES-4210 The renderer for h:outputLink should not prepend the namespace prefix to parameter names [2.2 backport]

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
+++ b/jsf-ri/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
@@ -47,12 +47,9 @@ import java.util.logging.Level;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIOutput;
-import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
-import com.sun.faces.config.WebConfiguration;
-import com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter;
 import com.sun.faces.renderkit.Attribute;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
@@ -74,15 +71,8 @@ public class OutputLinkRenderer extends LinkRenderer {
     private static final Attribute[] ATTRIBUTES =
           AttributeManager.getAttributes(AttributeManager.Key.OUTPUTLINK);
 
-    protected boolean namespaceParameters;
-
     // ---------------------------------------------------------- Public Methods
 
-
-    public OutputLinkRenderer() {
-        WebConfiguration webConfig = WebConfiguration.getInstance();
-        namespaceParameters = webConfig.isOptionEnabled(BooleanWebContextInitParameter.NamespaceParameters);
-    }
 
     @Override
     public void decode(FacesContext context, UIComponent component) {
@@ -230,17 +220,9 @@ public class OutputLinkRenderer extends LinkRenderer {
         StringBuffer sb = new StringBuffer();
         sb.append(hrefVal);
         boolean paramWritten = (hrefVal.indexOf('?') > 0);
-        String namingContainerId = null;
-        if (namespaceParameters) {
-            UIViewRoot viewRoot = context.getViewRoot();
-            namingContainerId = viewRoot.getContainerClientId(context);
-        }
         for (int i = 0, len = paramList.length; i < len; i++) {
             String pn = paramList[i].name;
             if (pn != null && pn.length() != 0) {
-            	if (namingContainerId != null) {
-            		pn = namingContainerId + pn;
-            	}
                 String pv = paramList[i].value;
                 sb.append((paramWritten) ? '&' : '?');
                 sb.append(URLEncoder.encode(pn,"UTF-8"));


### PR DESCRIPTION
/cc @stiemannkj1 @BalusC