### PR TITLE
.Render jsf.js as resource component 2.1.x

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/jsf-ri/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -1081,18 +1081,13 @@ public class RenderKitUtils {
             setScriptAsRendered(context);
             return;
         }
-        // Since we've now determined that it's not in the page, we need to add it.
 
-        ResourceHandler handler = context.getApplication().getResourceHandler();
-        Resource resource = handler.createResource(name, library);
-        ResponseWriter writer = context.getResponseWriter();
-        writer.write('\n');
-        writer.startElement("script", null);
-        writer.writeAttribute("type", "text/javascript", null);
-        writer.writeAttribute("src", ((resource != null) ? resource.getRequestPath() : ""), null);
-        writer.endElement("script");
-        writer.append('\r');
-        writer.append('\n');
+        // Since we've now determined that it's not in the page, we need to add it.
+        UIOutput output = new UIOutput();
+        output.setRendererType("javax.faces.resource.Script");
+        output.getAttributes().put("name", name);
+        output.getAttributes().put("library", library);
+        output.encodeAll(context);
 
         // Set the context to record script as included
         setScriptAsRendered(context);


### PR DESCRIPTION
…7 [2.1 backport] Always render jsf.js as a component

Rendering jsf.js as a component invokes the renderkit and allows libraries to
easily decorate its renderer.