### PR TITLE
Fixes Mojarra #4279: ConfigurableNavigationHandler.getNavigationCase() is not idempotent.

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
+++ b/jsf-ri/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
@@ -88,6 +88,29 @@ import javax.faces.flow.ViewNode;
 
 public class NavigationHandlerImpl extends ConfigurableNavigationHandler {
 
+    // Private Constants
+    private static final String RESET_FLOW_HANDLER_STATE_KEY = NavigationHandlerImpl.class.getName() +
+        "_RESET_FLOW_HANDLER_STATE_KEY";
+
+    public static boolean isResetFlowHandlerState(FacesContext facesContext) {
+
+        Boolean obtainingNavigationCase = (Boolean) FacesContext.getCurrentInstance().getAttributes()
+            .get(RESET_FLOW_HANDLER_STATE_KEY);
+        return obtainingNavigationCase != null && obtainingNavigationCase;
+    }
+
+    public static void setResetFlowHandlerStateIfUnset(FacesContext facesContext, boolean resetFlowHandlerState) {
+        Map<Object, Object> attributes = facesContext.getAttributes();
+
+        if (!attributes.containsKey(RESET_FLOW_HANDLER_STATE_KEY)) {
+            attributes.put(RESET_FLOW_HANDLER_STATE_KEY, resetFlowHandlerState);
+        }
+    }
+
+    public static void unsetResetFlowHandlerState(FacesContext facesContext) {
+        facesContext.getAttributes().remove(RESET_FLOW_HANDLER_STATE_KEY);
+    }
+
     // Log instance for this class
     private static final Logger logger = FacesLogger.APPLICATION.getLogger();
 
@@ -146,13 +169,19 @@ public class NavigationHandlerImpl extends ConfigurableNavigationHandler {
         Util.notNull("context", context);
         Util.notNull("toFlowDocumentId", toFlowDocumentId);
         NavigationCase result = null;
-        CaseStruct caseStruct = getViewId(context, fromAction, outcome, toFlowDocumentId);
-        if (null != caseStruct) {
-            result = caseStruct.navCase;
+        setResetFlowHandlerStateIfUnset(context, true);
+        try {
+            CaseStruct caseStruct = getViewId(context, fromAction, outcome, toFlowDocumentId);
+            if (null != caseStruct) {
+                result = caseStruct.navCase;
+            }
+
+            return result;
+            }
+        finally {
+            unsetResetFlowHandlerState(context);
         }
-        
-        return result;
-        
+
     }
     
     
@@ -164,9 +193,15 @@ public class NavigationHandlerImpl extends ConfigurableNavigationHandler {
     @Override
     public Map<String, Set<NavigationCase>> getNavigationCases() {
         FacesContext context = FacesContext.getCurrentInstance();
-        Map<String, Set<NavigationCase>> result = getNavigationMap(context);
+        setResetFlowHandlerStateIfUnset(context, true);
+        try {
+            Map<String, Set<NavigationCase>> result = getNavigationMap(context);
 
-        return result;
+            return result;
+        }
+        finally {
+            unsetResetFlowHandlerState(context);
+        }
 
     }
 

--- a/jsf-ri/src/main/java/com/sun/faces/flow/FlowHandlerImpl.java
+++ b/jsf-ri/src/main/java/com/sun/faces/flow/FlowHandlerImpl.java
@@ -40,6 +40,7 @@
  */
 package com.sun.faces.flow;
 
+import com.sun.faces.application.NavigationHandlerImpl;
 import com.sun.faces.util.Util;
 import java.io.Serializable;
 import java.text.MessageFormat;
@@ -570,12 +571,38 @@ public class FlowHandlerImpl extends FlowHandler {
             
         }
         
+        private void decrementMaxReturnDepth() {
+            FacesContext context = FacesContext.getCurrentInstance();
+            Map<Object, Object> attrs = context.getAttributes();
+            if (attrs.containsKey(FLOW_RETURN_DEPTH_PARAM_NAME)) {
+
+                Integer cur = (Integer) attrs.get(FLOW_RETURN_DEPTH_PARAM_NAME);
+
+                if (cur > 1) {
+                    attrs.put(FLOW_RETURN_DEPTH_PARAM_NAME, (Integer) cur - 1);
+                }
+                else {
+                    attrs.remove(FLOW_RETURN_DEPTH_PARAM_NAME);
+                }
+            }
+            
+        }
+        
         public void pushReturnMode() {
             this.incrementMaxReturnDepth();
             this.returnDepth++;
         }
         
         public void popReturnMode() {
+
+            // Mojarra #4279 If ConfigureableNavigationHandler is attempting to obtain a NavigationCase outside of
+            // OutcomeTargetRenderer, then this method must perform exactly the reverse of pushReturnMode() to ensure
+            // that ConfigureableNavigationHandler's calls are idempotent. For more details, see
+            // https://github.com/javaserverfaces/mojarra/issues/4279
+            if (NavigationHandlerImpl.isResetFlowHandlerState(FacesContext.getCurrentInstance())) {
+                this.decrementMaxReturnDepth();
+            }
+
             this.returnDepth--;
         }
 

--- a/jsf-ri/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetRenderer.java
+++ b/jsf-ri/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetRenderer.java
@@ -40,6 +40,7 @@
 
 package com.sun.faces.renderkit.html_basic;
 
+import com.sun.faces.application.NavigationHandlerImpl;
 import com.sun.faces.flow.FlowHandlerImpl;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.renderkit.Attribute;
@@ -142,10 +143,16 @@ public abstract class OutcomeTargetRenderer extends HtmlBasicRenderer {
         }
         String toFlowDocumentId = (String) component.getAttributes().get(ActionListener.TO_FLOW_DOCUMENT_ID_ATTR_NAME);
         NavigationCase navCase = null;
-        if (null == toFlowDocumentId) {
-            navCase = ((ConfigurableNavigationHandler) navHandler).getNavigationCase(context, null, outcome);            
-        } else {
-            navCase = ((ConfigurableNavigationHandler) navHandler).getNavigationCase(context, null, outcome, toFlowDocumentId);            
+        NavigationHandlerImpl.setResetFlowHandlerStateIfUnset(context, false);
+        try {
+            if (null == toFlowDocumentId) {
+                navCase = ((ConfigurableNavigationHandler) navHandler).getNavigationCase(context, null, outcome);            
+            } else {
+                navCase = ((ConfigurableNavigationHandler) navHandler).getNavigationCase(context, null, outcome, toFlowDocumentId);            
+            }
+        }
+        finally {
+            NavigationHandlerImpl.unsetResetFlowHandlerState(context);
         }
 
         if (navCase == null && logger.isLoggable(Level.WARNING)) {

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/pom.xml
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/pom.xml
@@ -45,32 +45,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.sun.faces.test.webprofile</groupId>
+        <groupId>com.sun.faces.test.webprofile.flow</groupId>
         <artifactId>pom</artifactId>
         <version>2.2.15-SNAPSHOT</version>
     </parent>
     <groupId>com.sun.faces.test.webprofile.flow</groupId>
-    <artifactId>pom</artifactId>
-    <packaging>pom</packaging>
-    <name>Mojarra ${project.version} - Test - Web-Profile - Flow</name>
-    <modules>
-        <module>basic-empty-flow-def</module>
-        <module>basic-implicit</module>
-        <module>basic-multi-page</module>
-        <module>basic-multi-page-fdl-in-web-inf</module>
-        <module>basic_faces_flow_call</module>
-        <module>basic_implicit_in_jar</module>
-        <module>basic_implicit_template</module>
-        <module>basic_method_call</module>
-        <module>basic_switch</module>
-        <module>defining_document_id</module>
-        <module>factory</module>
-        <module>intermediate</module>
-        <module>multi-page-from-jar</module>
-        <module>nested_flows</module>
-        <module>parameter_faces_flow_call</module>
-        <module>return_from_depth</module>
-        <module>view_node_differences</module>
-        <module>getNavigationCase-not-idempotent-issue-4279</module>
-    </modules>
+    <artifactId>getNavigationCase-not-idempotent-issue-4279</artifactId>
+    <packaging>war</packaging>
+    <name>Mojarra ${project.version} - Test - Web-Profile - Flow - getNavigationCase not idempotent-issue-4279</name>
+    <build>
+        <finalName>test-webprofile-flow-getNavigationCase-not-idempotent-issue-4279</finalName>
+    </build>
+    <properties>
+        <netbeans.hint.deploy.server>gfv3ee6</netbeans.hint.deploy.server>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 </project>

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/java/com/sun/faces/test/webprofile/flow/issue4279getNavigationCaseNotIdempotent/Flow1Bean.java
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/java/com/sun/faces/test/webprofile/flow/issue4279getNavigationCaseNotIdempotent/Flow1Bean.java
@@ -1,0 +1,74 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ * Copyright (c) 1997-2012 Oracle and/or its affiliates. All rights reserved.
+ * 
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ * 
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ * 
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ * 
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ * 
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+
+ */
+package com.sun.faces.test.webprofile.flow.issue4279getNavigationCaseNotIdempotent;
+
+import java.io.Serializable;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.faces.flow.FlowScoped;
+import javax.inject.Named;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+@Named
+@FlowScoped(Flow1Bean.TITLE)
+public class Flow1Bean implements Serializable {
+
+	static final String TITLE = "flow1";
+	private static final long serialVersionUID = 4380151863471254093L;
+
+	@PreDestroy
+	public void destroy() {
+		System.out.println("Flow1Bean @PreDestroy Called.");
+	}
+
+	public String getTitle() {
+		return TITLE;
+	}
+
+	@PostConstruct
+	public void initialize() {
+		System.out.println("Flow1Bean @PostConstruct Called.");
+	}
+}

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/java/com/sun/faces/test/webprofile/flow/issue4279getNavigationCaseNotIdempotent/Flow2Bean.java
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/java/com/sun/faces/test/webprofile/flow/issue4279getNavigationCaseNotIdempotent/Flow2Bean.java
@@ -1,0 +1,88 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ * Copyright (c) 1997-2012 Oracle and/or its affiliates. All rights reserved.
+ * 
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ * 
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ * 
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ * 
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ * 
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+
+ */
+package com.sun.faces.test.webprofile.flow.issue4279getNavigationCaseNotIdempotent;
+
+import java.io.Serializable;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.faces.application.Application;
+import javax.faces.application.ConfigurableNavigationHandler;
+import javax.faces.context.FacesContext;
+import javax.faces.flow.FlowScoped;
+import javax.inject.Named;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+@Named
+@FlowScoped(Flow2Bean.TITLE)
+public class Flow2Bean implements Serializable {
+
+	static final String TITLE = "flow2";
+	private static final long serialVersionUID = -4380151863471254093L;
+
+	@PreDestroy
+	public void destroy() {
+		System.out.println("Flow2Bean @PreDestroy Called.");
+	}
+
+	public String getTitle() {
+		return TITLE;
+	}
+
+	@PostConstruct
+	public void initialize() {
+		System.out.println("Flow2Bean @PostConstruct Called.");
+	}
+
+	public String returnFromFlow2() {
+
+		FacesContext facesContext = FacesContext.getCurrentInstance();
+		Application application = facesContext.getApplication();
+		ConfigurableNavigationHandler configurableNavigationHandler = (ConfigurableNavigationHandler)
+			application.getNavigationHandler();
+		configurableNavigationHandler.getNavigationCase(facesContext, "returnFromFlow2", "returnFromFlow2");
+
+		return "returnFromFlow2";
+	}
+}

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/WEB-INF/beans.xml
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file can be an empty text file (0 bytes) -->
+<!-- We're declaring the schema to save you time if you do have to configure 
+   this in the future -->
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+        http://java.sun.com/xml/ns/javaee 
+        http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/WEB-INF/web.xml
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <context-param>
+        <param-name>javax.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>javax.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>${webapp.partialStateSaving}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>${webapp.stateSavingMethod}</param-value>
+    </context-param>
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>/faces/*</url-pattern>
+    </servlet-mapping>
+    <welcome-file-list>
+        <welcome-file>faces/index.xhtml</welcome-file>
+    </welcome-file-list>
+</web-app>

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow1/flow1-flow.xml
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow1/flow1-flow.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
+	<flow-definition id="flow1">
+		<flow-return id="returnFromFlow1">
+			<from-outcome>/index.xhtml</from-outcome>
+		</flow-return>
+		<flow-call id="callFlow2">
+			<flow-reference>
+				<flow-id>flow2</flow-id>
+			</flow-reference>
+		</flow-call>
+	</flow-definition>
+</faces-config>

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow1/flow1.xhtml
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow1/flow1.xhtml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<f:view xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:h="http://xmlns.jcp.org/jsf/html">
+	<h:head>
+	</h:head>
+	<h:body>
+		<h:form prependId="false">
+			<h1>#{flow1Bean.title}</h1>
+			<h:commandButton id="callFlow2" action="callFlow2" value="callFlow2" />
+		</h:form>
+	</h:body>
+</f:view>

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow1/returnFromFlow2.xhtml
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow1/returnFromFlow2.xhtml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<f:view xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:h="http://xmlns.jcp.org/jsf/html">
+	<h:head>
+	</h:head>
+	<h:body>
+		<h:form prependId="false">
+			<h1>#{flow1Bean.title}</h1>
+			<h:commandButton id="returnFromFlow1" action="returnFromFlow1" value="returnFromFlow1" />
+		</h:form>
+	</h:body>
+</f:view>

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow2/flow2-flow.xml
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow2/flow2-flow.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
+	<flow-definition id="flow2">
+		<flow-return id="returnFromFlow2">
+			<from-outcome>/flow1/returnFromFlow2.xhtml</from-outcome>
+		</flow-return>
+	</flow-definition>
+</faces-config>

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow2/flow2.xhtml
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/flow2/flow2.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<f:view xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:h="http://xmlns.jcp.org/jsf/html">
+	<h:head>
+	</h:head>
+	<h:body>
+		<h:form prependId="false">
+			<h1>#{flow2Bean.title}</h1>
+			<h:commandButton id="returnFromFlow2" action="returnFromFlow2" value="returnFromFlow2" />
+			<h:commandButton id="call_getNavigationCase_and_returnFromFlow2" action="#{flow2Bean.returnFromFlow2}"
+				value="Call NavigationHandler.getNavigationCase(facesContext, &quot;returnFromFlow2&quot;, &quot;returnFromFlow2&quot;) then returnFromFlow2" />
+		</h:form>
+	</h:body>
+</f:view>

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/index.xhtml
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/main/webapp/index.xhtml
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+    <h:head>
+    </h:head>
+
+    <h:body>
+		<h:form prependId="false">
+			<h:commandButton id="flow1" action="flow1" value="flow1" />
+		</h:form>
+    </h:body>
+</html>

--- a/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/test/java/com/sun/faces/test/webprofile/flow/issue4279getNavigationCaseNotIdempotent/Issue4279GetNavigationCaseNotIdempotentIT.java
+++ b/test/web-profile/flow/getNavigationCase-not-idempotent-issue-4279/src/test/java/com/sun/faces/test/webprofile/flow/issue4279getNavigationCaseNotIdempotent/Issue4279GetNavigationCaseNotIdempotentIT.java
@@ -1,0 +1,122 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2012 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.faces.test.webprofile.flow.issue4279getNavigationCaseNotIdempotent;
+
+import com.gargoylesoftware.htmlunit.html.HtmlInput;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import java.io.IOException;
+import static org.junit.Assert.assertNotNull;
+
+public class Issue4279GetNavigationCaseNotIdempotentIT {
+    /**
+     * Stores the web URL.
+     */
+    private String webUrl;
+    /**
+     * Stores the web client.
+     */
+    private WebClient webClient;
+
+    /**
+     * Setup before testing.
+     * 
+     * @throws Exception when a serious error occurs.
+     */
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    /**
+     * Cleanup after testing.
+     * 
+     * @throws Exception when a serious error occurs.
+     */
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    /**
+     * Setup before testing.
+     */
+    @Before
+    public void setUp() {
+        webUrl = System.getProperty("integration.url");
+        webClient = new WebClient();
+    }
+
+    /**
+     * Tear down after testing.
+     */
+    @After
+    public void tearDown() {
+        webClient.closeAllWindows();
+    }
+
+    @Test
+    public void testIssue4279GetNavigationCaseNotIdempotent() throws Exception {
+
+		doTestIssue4279GetNavigationCaseNotIdempotent("call_getNavigationCase_and_returnFromFlow2");
+		doTestIssue4279GetNavigationCaseNotIdempotent("returnFromFlow2");
+	}
+
+	private void doTestIssue4279GetNavigationCaseNotIdempotent(String returnFromFlow2ButtonId) throws IOException {
+
+		HtmlPage page = webClient.getPage(webUrl);
+		assertNotNull(page.getElementById("flow1"));
+		HtmlInput flow1Button = (HtmlInput) page.getElementById("flow1");
+		page = flow1Button.click();
+		assertNotNull(page.getElementById("callFlow2"));
+		HtmlInput callFlow2Button = (HtmlInput) page.getElementById("callFlow2");
+		page = callFlow2Button.click();
+		assertNotNull(page.getElementById("returnFromFlow2"));
+		HtmlInput returnFromFlow2Button = (HtmlInput) page.getElementById(returnFromFlow2ButtonId);
+		page = returnFromFlow2Button.click();
+		assertNotNull(page.getElementById("returnFromFlow1"));
+		HtmlInput returnFromFlow1Button = (HtmlInput) page.getElementById("returnFromFlow1");
+		page = returnFromFlow1Button.click();
+		assertNotNull(page.getElementById("flow1"));
+	}
+}


### PR DESCRIPTION
Calling ConfigurableNavigationHandler.getNavigationCase() before exiting nested flow causes outer flow to be exited prematurely